### PR TITLE
Fix TS typings

### DIFF
--- a/inspire-tree-dom.d.ts
+++ b/inspire-tree-dom.d.ts
@@ -1,34 +1,33 @@
-/// <reference types="es6-promise" />
 
-declare module "inspire-tree-dom" {
-    /**
-     * Validation callback for validating drag node may be dropped into the target.
-     */
-    interface DropTargetValidator {
-        (dragNode: TreeNode, targetNode: TreeNode): boolean;
-    }
+import { TreeNode } from 'inspire-tree';
 
-    /**
-     * Represents a tree DOM configuration object
-     */
-    interface Config {
-        autoLoadMore?: boolean;
-        deferredRendering?: boolean;
-        dragAndDrop?: {
-            enabled?: boolean;
-            validateOn?: string;
-            validate: DropTargetValidator
-        };
-        nodeHeight?: number;
-        showCheckboxes?: boolean;
-        dragTargets?: Array<string>;
-        tabindex?: number;
-        target: HTMLElement;
-    }
-
-    class InspireTreeDOM {
-        constructor(tree: any, opts: Config);
-    }
-
-	export default InspireTreeDOM;
+/**
+ * Validation callback for validating drag node may be dropped into the target.
+ */
+export interface DropTargetValidator {
+    (dragNode: TreeNode, targetNode: TreeNode): boolean;
 }
+
+/**
+ * Represents a tree DOM configuration object
+ */
+export interface Config {
+    autoLoadMore?: boolean;
+    deferredRendering?: boolean;
+    dragAndDrop?: {
+        enabled?: boolean;
+        validateOn?: string;
+        validate: DropTargetValidator
+    };
+    nodeHeight?: number;
+    showCheckboxes?: boolean;
+    dragTargets?: Array<string>;
+    tabindex?: number;
+    target: HTMLElement;
+}
+
+declare class InspireTreeDOM {
+    constructor(tree: any, opts: Config);
+}
+
+export default InspireTreeDOM;

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "eslint-plugin-inferno": "^7.0.1",
     "inferno": "^3.8.2",
     "inferno-component": "^3.8.2",
+    "inspire-tree": "^4.2.0",
     "jquery": "^3.2.1",
     "karma": "^1.7.1",
     "karma-chai-plugins": "^0.9.0",
@@ -46,6 +47,7 @@
     "setup": "cp hooks/pre-commit .git/hooks/pre-commit"
   },
   "main": "dist/inspire-tree-dom.js",
+  "types": "inspire-tree-dom.d.ts",
   "files": [
     "dist",
     "src",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2145,6 +2145,10 @@ inquirer@^3.0.6:
     strip-ansi "^3.0.0"
     through "^2.3.6"
 
+inspire-tree@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/inspire-tree/-/inspire-tree-4.2.0.tgz#add52e05ee4728bf7ae6c6622ebf9f544cc58c3e"
+
 invariant@^2.2.0, invariant@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.2.tgz#9e1f56ac0acdb6bf303306f338be3b204ae60360"


### PR DESCRIPTION
Use external module
Fix undefined interface` TreeNode` by importing it (this needs https://github.com/helion3/inspire-tree/pull/173)
Add types field to package.json

Without this change it's not possible to import this in TS:

![image](https://user-images.githubusercontent.com/10532611/33453574-fab891e0-d5ca-11e7-805a-bc5fd17b41a0.png)
