### PR TITLE
add missing lodash imports

### DIFF
--- a/src/dom/list-item.js
+++ b/src/dom/list-item.js
@@ -1,3 +1,4 @@
+import * as _ from 'lodash';
 import { Component } from 'inferno';
 import Checkbox from './checkbox';
 import classlist from '../lib/classlist';

--- a/src/dom/list.js
+++ b/src/dom/list.js
@@ -1,3 +1,4 @@
+import * as _ from 'lodash';
 import { Component } from 'inferno';
 import ListItem from './list-item';
 import stateComparator from '../lib/state-comparator';

--- a/src/dom/node-anchor.js
+++ b/src/dom/node-anchor.js
@@ -1,3 +1,4 @@
+import * as _ from 'lodash';
 import { Component } from 'inferno';
 import classlist from '../lib/classlist';
 import EditForm from './edit-form';


### PR DESCRIPTION
my project uses inspire-tree-dom but does not use lodash. This PR should make inspire-tree-dom work within my project without having to explicitly require lodash.